### PR TITLE
過去の一覧・詳細追加

### DIFF
--- a/frontend/src/components/4other-user/OtherUserDetail.tsx
+++ b/frontend/src/components/4other-user/OtherUserDetail.tsx
@@ -1,10 +1,14 @@
 import React from 'react'
+import { BaseLayout } from 'layouts'
+import { LinkButton } from 'templates'
+import Detail from 'templates/detail/Detail'
 
 const OtherUserDetail = () => {
    return (
-      <div>
-         
-      </div>
+      <BaseLayout subtitle="other-user-ddetail">
+      <Detail/>
+      <LinkButton to='/top' sx={{ display: 'flex', justifyContent: 'center' }}>参加申請</LinkButton>
+      </BaseLayout>
    )
 }
 

--- a/frontend/src/components/4other-user/OtherUserIchiran.tsx
+++ b/frontend/src/components/4other-user/OtherUserIchiran.tsx
@@ -3,7 +3,10 @@ import Ichiran from 'templates/ichiran/Ichiran'
 
 const OtherUserIchiran = () => {
    return (
-      <Ichiran/>
+      <Ichiran 
+      url={"trade-detail"}
+      pageDescription={"開催予定のトレード一覧"}
+      />
    )
 }
 

--- a/frontend/src/components/4other-user/past-trade/PastDetail.tsx
+++ b/frontend/src/components/4other-user/past-trade/PastDetail.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
+import Detail from 'templates/detail/Detail'
 
 const PastDetail = () => {
    return (
-      <div>
-         
-      </div>
+      <Detail/>
    )
 }
 

--- a/frontend/src/components/4other-user/past-trade/PastIchiran.tsx
+++ b/frontend/src/components/4other-user/past-trade/PastIchiran.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
+import Ichiran from 'templates/ichiran/Ichiran'
 
 const PastIchiran = () => {
    return (
-      <div>
-         
-      </div>
+      <Ichiran 
+      url={"past-trade-detail"}
+      pageDescription={"過去のトレード一覧"}
+      />
    )
 }
 

--- a/frontend/src/templates/LinkButton.tsx
+++ b/frontend/src/templates/LinkButton.tsx
@@ -38,7 +38,7 @@ const CustomButton = styled(Button)(({ theme }) => ({
  }));
 
 type LinkButtonProps = {
-  to: string;
+  to: any;
 } & ButtonProps<ButtonTypeMap<{}, 'a'>['defaultComponent']>;
 
 const LinkButton = (props: LinkButtonProps) => {

--- a/frontend/src/templates/LinkButton2.tsx
+++ b/frontend/src/templates/LinkButton2.tsx
@@ -20,7 +20,7 @@ const CustomButton = styled(Button)(({ theme }) => ({
  }));
 
 type LinkButtonProps = {
-  to: string;
+  to: any;
 } & ButtonProps<ButtonTypeMap<{}, 'a'>['defaultComponent']>;
 
 const LinkButton2 = (props: LinkButtonProps) => {

--- a/frontend/src/templates/detail/Detail.tsx
+++ b/frontend/src/templates/detail/Detail.tsx
@@ -1,19 +1,26 @@
 import React from 'react'
-import { Box, Container } from '@mui/material'
+import { Box, Button, Container } from '@mui/material'
 import { BaseLayout } from 'layouts'
 import ImageList from '@mui/material/ImageList';
 import ImageListItem from '@mui/material/ImageListItem';
 import { Typography } from '@mui/material';
 import { Grid } from '@mui/material';
 import { Description } from '@mui/icons-material';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 
 
 //API通信で使うURLは変数にする。propsでいけるかも。
 
 const Detail = () => {
+  const {state} = useLocation();
+  const history = useHistory();
+  const id = useParams();
+
+  const onClickBack = () => {
+    history.goBack();
+  }
    //const { title, date, currentCapa, maxCapa, place, image, description } = props;   //propsではない。
    return (
-      <BaseLayout subtitle='Detail Page'>
          <Container maxWidth="md" sx={{ marginTop: 10 }}>
          <Grid container sx={{marginBottom: 8}}>
             <Grid item>
@@ -23,7 +30,7 @@ const Detail = () => {
             </Grid>
             <Grid item>
                 <Typography variant='h4' color='textSecondary' sx={{ marginLeft: 8 }}>
-                  名前{ } さんの投稿詳細
+                  {state} さんの投稿詳細
                 </Typography>
             </Grid>
           </Grid>
@@ -62,8 +69,8 @@ const Detail = () => {
             </ImageListItem>
             ))}
          </ImageList>
+         <Button onClick={onClickBack}>一覧に戻る</Button>
          </Container>
-      </BaseLayout>
    )
 }
 

--- a/frontend/src/templates/ichiran/Ichiran.tsx
+++ b/frontend/src/templates/ichiran/Ichiran.tsx
@@ -66,9 +66,10 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
-const Ichiran = () => {   
-
+const Ichiran = (props: {url: string, pageDescription: string}) => {   
+  const {url, pageDescription} = props;
   const classes = useStyles();
+  const stateA = "渡邊一真";
 
   return (
       <BaseLayout subtitle='Album'>
@@ -76,7 +77,7 @@ const Ichiran = () => {
         <Toolbar>
           <CameraIcon sx={{ mr: 2 }} />
           <Typography variant="h6" color="inherit" noWrap>
-             ああああ(通知つけるならここか)
+             {props.pageDescription}
           </Typography>
         </Toolbar>
       </AppBar>
@@ -89,7 +90,7 @@ const Ichiran = () => {
             </Grid>
             <Grid item>
                 <Typography variant='h4' color='textSecondary' sx={{ marginLeft: 8 }}>
-                  名前{ } さんの投稿一覧
+                  {stateA} さんの投稿一覧
                 </Typography>
             </Grid>
           </Grid>
@@ -121,7 +122,7 @@ const Ichiran = () => {
                     </Typography>
                   </CardContent>
                   <CardActions>
-                    <LinkButton size="small" to="/detail">詳細ページへ</LinkButton>
+                  <LinkButton size="small" to={{pathname: `/${props.url}`, state: stateA}}>詳細ページへ</LinkButton>
                   </CardActions>
                 </Card>
               </Grid>


### PR DESCRIPTION
LinkButtonのtoの型をstringからanyに変更(場所によってはstateを渡す必要があるため)
Stateで名前を簡単に一覧から詳細に渡すことができた
Ichiran.tsx「詳細ページへ」ボタンのURL可変に
pageDescription(props)やっぱり追加